### PR TITLE
Add transcript metadata display

### DIFF
--- a/av_core.gemspec
+++ b/av_core.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'irb', '~> 1.2' # workaroundfor https://github.com/bundler/bundler/issues/6929
   spec.add_development_dependency 'listen', '>= 3.0.5', '< 3.2'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-support', '~> 3.9'
   spec.add_development_dependency 'rubocop', '1.26.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'

--- a/av_core.gemspec
+++ b/av_core.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'irb', '~> 1.2' # workaroundfor https://github.com/bundler/bundler/issues/6929
   spec.add_development_dependency 'listen', '>= 3.0.5', '< 3.2'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-support', '~> 3.9'
   spec.add_development_dependency 'rubocop', '1.26.0'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6.0'

--- a/lib/berkeley_library/av/constants.rb
+++ b/lib/berkeley_library/av/constants.rb
@@ -5,6 +5,10 @@ module BerkeleyLibrary
       TAG_LINK_FIELD = '856'.freeze
       TAG_TRACK_FIELD = '998'.freeze
       TAG_TIND_ID = '001'.freeze
+      TAG_TRANSCRIPT_FIELD = '856'.freeze
+
+      SUBFIELD_CODE_URI = :u
+      SUBFIELD_CODE_LINKTEXT = :y
 
       # TODO: use marc/spec
       TAG_TIND_CATALOG_ID = '901'.freeze

--- a/lib/berkeley_library/av/metadata/fields.rb
+++ b/lib/berkeley_library/av/metadata/fields.rb
@@ -14,7 +14,7 @@ module BerkeleyLibrary
         TRACKS = Field.new(order: 99, label: 'Tracks', spec: TAG_TRACK_FIELD, subfield_order: %w[g t a])
         CATALOG_LINK = Field.new(order: 998, label: 'Linked Resources', spec: "#{TAG_LINK_FIELD}{^1=\\4}{^2=\\1}")
         # rubocop:disable Layout/LineLength
-        Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
+        TRANSCRIPTS = Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
         # rubocop:enable Layout/LineLength
 
         STANDARD_FIELDS = [

--- a/lib/berkeley_library/av/metadata/fields.rb
+++ b/lib/berkeley_library/av/metadata/fields.rb
@@ -13,7 +13,9 @@ module BerkeleyLibrary
         CREATOR_CORPORATE = Field.new(order: 2, label: 'Creator', spec: '710')
         TRACKS = Field.new(order: 99, label: 'Tracks', spec: TAG_TRACK_FIELD, subfield_order: %w[g t a])
         CATALOG_LINK = Field.new(order: 998, label: 'Linked Resources', spec: "#{TAG_LINK_FIELD}{^1=\\4}{^2=\\1}")
-        TRANSCRIPTS = Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
+        # rubocop:disable Layout/LineLength
+        Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
+        # rubocop:enable Layout/LineLength
 
         STANDARD_FIELDS = [
           TITLE,

--- a/lib/berkeley_library/av/metadata/fields.rb
+++ b/lib/berkeley_library/av/metadata/fields.rb
@@ -12,7 +12,8 @@ module BerkeleyLibrary
         CREATOR_PERSONAL = Field.new(order: 2, label: 'Creator', spec: '700')
         CREATOR_CORPORATE = Field.new(order: 2, label: 'Creator', spec: '710')
         TRACKS = Field.new(order: 99, label: 'Tracks', spec: TAG_TRACK_FIELD, subfield_order: %w[g t a])
-        CATALOG_LINK = Field.new(order: 999, label: 'Linked Resources', spec: "#{TAG_LINK_FIELD}{^1=\\4}{^2=\\1}")
+        CATALOG_LINK = Field.new(order: 998, label: 'Linked Resources', spec: "#{TAG_LINK_FIELD}{^1=\\4}{^2=\\1}")
+        TRANSCRIPTS = Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
 
         STANDARD_FIELDS = [
           TITLE,
@@ -20,6 +21,7 @@ module BerkeleyLibrary
           CREATOR_PERSONAL,
           CREATOR_CORPORATE,
           TRACKS,
+          TRANSCRIPTS,
           CATALOG_LINK
         ].freeze
 

--- a/spec/data/record-audio-multiple-856s.xml
+++ b/spec/data/record-audio-multiple-856s.xml
@@ -1,0 +1,55 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <controlfield tag="001">207666</controlfield>
+  <controlfield tag="005">20231106135319.0</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">drilmav-00004</subfield>
+  </datafield>
+  <datafield tag="245" ind1=" " ind2=" ">
+    <subfield code="a">On changes regarding discrimination against people with disabilities</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">Audio</subfield>
+  </datafield>
+  <datafield tag="540" ind1=" " ind2=" ">
+    <subfield code="a">Researchers may make free and open use of the UC Berkeley Library’s digitized public domain materials. However, some materials in our online collections may be protected by U.S. copyright law (Title 17, U.S.C.). Use or reproduction of materials protected by copyright beyond that allowed by fair use (Title 17, U.S.C. § 107) requires permission from the copyright owners. The use or reproduction of some materials may also be restricted by terms of University of California gift or purchase agreements, privacy and publicity rights, or trademark law. Responsibility for determining rights status and permissibility of any use or reproduction rests exclusively with the researcher. To learn more or make inquiries, please see our permissions policies (https://www.lib.berkeley.edu/about/permissions-policies).
+</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Billings, Carol Fewell</subfield>
+  </datafield>
+  <datafield tag="852" ind1=" " ind2=" ">
+    <subfield code="c">The Bancroft Library</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="u">https://avplayer.lib.berkeley.edu/ROHOAudio/drilmav-00004</subfield>
+    <subfield code="y">Play Audio</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="u">https://digitalassets.lib.berkeley.edu/audio/transcript/Carol_Fewell_Billings_Transcript.pdf</subfield>
+    <subfield code="y">Transcript of audio file</subfield>
+  </datafield>
+  <datafield tag="902" ind1=" " ind2=" ">
+    <subfield code="d">2/3/21</subfield>
+    <subfield code="n">SMS</subfield>
+  </datafield>
+  <datafield tag="909" ind1="C" ind2="O">
+    <subfield code="o">oai:digicoll.lib.berkeley.edu:207666</subfield>
+    <subfield code="q">mcleanCalisphere_oai</subfield>
+  </datafield>
+  <datafield tag="980" ind1=" " ind2=" ">
+    <subfield code="a">DRILM: AV</subfield>
+  </datafield>
+  <datafield tag="982" ind1=" " ind2=" ">
+    <subfield code="b">Disability Rights and Independent Living Movement</subfield>
+  </datafield>
+  <datafield tag="982" ind1=" " ind2=" ">
+    <subfield code="a">Disability Rights Movement</subfield>
+  </datafield>
+  <datafield tag="998" ind1=" " ind2=" ">
+    <subfield code="g">billings1.mp3</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/lib/berkeley_library/av/metadata/field_spec.rb
+++ b/spec/lib/berkeley_library/av/metadata/field_spec.rb
@@ -66,6 +66,27 @@ module BerkeleyLibrary
           end
         end
 
+        context 'transcripts' do
+          it 'extracts transcripts from TIND records' do
+            marc_record = MARC::XMLReader.new('spec/data/record-audio-multiple-856s.xml').first
+            field = Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
+            value = field.value_from(marc_record)
+            expect(value).to be_a(Value)
+            expected_transcript = AV::Metadata::Link.new(
+              url: 'https://digitalassets.lib.berkeley.edu/audio/transcript/Carol_Fewell_Billings_Transcript.pdf',
+              body: 'Transcript of audio file'
+            )
+            expect(value.entries).to contain_exactly(expected_transcript)
+          end
+
+          it 'doesn\'t break when there are no transcripts' do
+            marc_record = MARC::XMLReader.new('spec/data/record-(pacradio)01469.xml').first
+            field = Field.new(order: 999, label: 'Transcripts', spec: "#{TAG_TRANSCRIPT_FIELD}{$y~\\Transcript}{^1=\\4}{^2=\\2}", subfield_order: %w[u y])
+            value = field.value_from(marc_record)
+            expect(value).to be_nil
+          end
+        end
+
         describe :hash do
           it 'returns the same hash for identical Fields' do
             f1 = Field.new(order: 2, label: 'Description', spec: '520$a')

--- a/spec/lib/berkeley_library/av/metadata/fields_spec.rb
+++ b/spec/lib/berkeley_library/av/metadata/fields_spec.rb
@@ -75,7 +75,8 @@ module BerkeleyLibrary
               Field.new(order: 86, spec: '991$a', label: 'Access', subfields_separator: ', '),
               Field.new(order: 89, spec: '982$a', label: 'Collection'),
               Field.new(order: 99, spec: '998', label: 'Tracks', subfield_order: %w[g t a]),
-              Field.new(order: 999, spec: '856{^1=\4}{^2=\1}', label: 'Linked Resources')
+              Field.new(order: 998, spec: '856{^1=\4}{^2=\1}', label: 'Linked Resources'),
+              Field.new(order: 999, spec: '856{$y~\Transcript}{^1=\4}{^2=\2}', label: 'Transcripts', subfield_order: %w[u y])
             ]
 
             fields = Fields.default_fields


### PR DESCRIPTION
When building the metadata fields object it will now include any special 856 tags that have "Transcript" in the text.